### PR TITLE
Fixe typos in Articulator Theory Hybrid Model

### DIFF
--- a/sca-manual.tex
+++ b/sca-manual.tex
@@ -992,7 +992,7 @@ The new model would need to address the shortcomings of \emph{Articulator Theory
 \item[Type] \emph{binary}
 \item[Examples]\
   \begin{itemize}
-    \item \texttt{[+relsease]}
+    \item \texttt{[+release]}
     pf bv pɸ bβ tθ dð ts dz tɬ dɮ tʃ dʒ tɕ dʑ ʈʂ ɖʐ cç ɟʝ kx gɣ qχ ɢʁ
 %    \item \texttt{[−release]}\\
 %    ...
@@ -1000,8 +1000,8 @@ The new model would need to address the shortcomings of \emph{Articulator Theory
 \item[Constraints]\
   \begin{enumerate}
   \itemsep1pt \parskip0pt \parsep0pt 
-    \item Any segment that is \texttt{[+release]} must be \texttt{[+consonanatl]}
-    \item Any segment that is \texttt{[+release]} must be \texttt{[−consonanatl]}
+    \item Any segment that is \texttt{[+release]} must be \texttt{[+consonantal]}
+    \item Any segment that is \texttt{[+release]} must be \texttt{[−consonantal]}
     \item Any segment that is \texttt{[+release]} must be \texttt{[−continuant]}
   \end{enumerate}
 \item[Resctrictions] Only meaningful for \texttt{[+consonantal,−sonorant, −continuant]}


### PR DESCRIPTION
Hey there, I noticed some typos in the .tex file and went ahead and fixed them.